### PR TITLE
Nmer Generation Speedup

### DIFF
--- a/crystalatte/crystalatte.py
+++ b/crystalatte/crystalatte.py
@@ -1212,12 +1212,8 @@ def distance_matrix(a, b):
     """
 
     assert(a.shape[1] == b.shape[1])
-    distm = np.zeros([a.shape[0], b.shape[0]])
-    
-    for i in range(a.shape[0]):
-    
-        for j in range(b.shape[0]):
-            distm[i, j] = np.linalg.norm(a[i] - b[j])
+
+    distm = np.sqrt(np.sum((a[:, np.newaxis, :] - b[np.newaxis, :, :]) ** 2, axis=2))
 
     r_min = np.min(distm)
 
@@ -1232,12 +1228,11 @@ def nre(elem, geom):
     computed nuclear repulsion energy.
     """
     
-    nre = 0.
-    for at1 in range(geom.shape[0]):
-
-        for at2 in range(at1):
-            dist = np.linalg.norm(geom[at1] - geom[at2])
-            nre += qcel.periodictable.to_Z(elem[at1]) * qcel.periodictable.to_Z(elem[at2]) / dist
+    Z = np.array([qcel.periodictable.to_Z(e) for e in elem])
+    dist = np.sqrt(np.sum((geom[:, np.newaxis, :] - geom[np.newaxis, :, :]) ** 2, axis=2))
+    np.fill_diagonal(dist, np.inf)
+    oodist = np.reciprocal(dist)
+    nre = np.einsum('x,xy,y', Z, oodist, Z, optimize=True) / 2.0
 
     return nre
 # ======================================================================
@@ -1262,36 +1257,16 @@ def chemical_space(elem, geom):
         system, where x is the number of atoms in the system.
     """
 
-    # Get the number of atoms in the N-mer
-    natoms = geom.shape[0]
-    
-    # Create a NumPy matrix
-    M = np.zeros((natoms,natoms))
+    Z = np.array([qcel.periodictable.to_Z(e) for e in elem])
+    dist = np.sqrt(np.sum((geom[:, np.newaxis, :] - geom[np.newaxis, :, :]) ** 2, axis=2))
 
-    # Iterate over atoms
-    for i in range(natoms):
-   
-        # Get the charge of atom i
-        charge_i = qcel.periodictable.to_Z(elem[i])
-        
-        # Fill the diagonal with the special polynomial from of:
-        # DOI: 10.1103/PhysRevLett.108.058301     
-        M[i,i] = 0.5 * np.power(charge_i, 2.4)
-    
-        for j in range(i):
-            
-            # Get the charge of atom j
-            charge_j = qcel.periodictable.to_Z(elem[j])
-            
-            # Compute distance between i and j
-            dist = np.linalg.norm(geom[i] - geom[j])
-            
-            # Compute Coulomb interaction between i and j
-            ij_elem = charge_i * charge_j / dist
+    np.fill_diagonal(dist, np.inf)
+    oodist = np.reciprocal(dist)
 
-            M[i,j] = ij_elem
-            # Symmetric Matrix 
-            M[j,i] = ij_elem
+    # Fill the diagonal with the special polynomial from:
+    # DOI: 10.1103/PhysRevLett.108.058301     
+    M = np.einsum('x,xy,y->xy', Z, oodist, Z, optimize=True)
+    np.fill_diagonal(M, (Z ** 2.4) / 2.0)
 
     # Solve the eigenvalue problem
     eigenvalues, eigenvectors = np.linalg.eig(M)

--- a/crystalatte/tests/test_99_amm_psi4api.py
+++ b/crystalatte/tests/test_99_amm_psi4api.py
@@ -119,6 +119,21 @@ def test_psi4api_ammonia():
     assert compare_values(6.459398295191971, min(nmers["4mer-0+1+2+3"]["com_monomer_separations"]),   atol=1.e-8)
     assert compare_values(6.459398295191971, min(nmers["5mer-0+1+2+3+4"]["com_monomer_separations"]), atol=1.e-8)
 
+    # Test the fist eight eigenvalues of the chemical similarity matrix for each N-mer
+    ref_eigenvalues = {
+        "2mer-0+1" :       [61.0577465, 47.27888919,   0.47526893,  0.24647406,  0.19289154,  0.17243445, 0.15959053,  0.1341196],
+        "3mer-0+1+2" :     [68.7489044, 47.64038823,  46.16025,     0.54602448,  0.27553,     0.24654741, 0.19155801,  0.18623255],
+        "3mer-0+1+5" :     [67.98553018, 47.27916218, 47.27916218,  0.56261868,  0.24797375,  0.24797375, 0.21507249, 0.17507582],
+        "4mer-0+1+2+3" :   [76.65031347, 47.80875755, 46.16191286, 46.16191286,  0.59866536,  0.27665228,  0.27665228,  0.25452003],
+        "5mer-0+1+2+3+4" : [81.63568805, 50.70144021, 47.31855835, 46.16210417, 45.17840185,  0.64552605,  0.33151774,  0.28139148],
+    }
+
+    assert compare_values(ref_eigenvalues["2mer-0+1"], nmers["2mer-0+1"]["chsev"][:8], atol=1e-7)
+    assert compare_values(ref_eigenvalues["3mer-0+1+2"], nmers["3mer-0+1+2"]["chsev"][:8], atol=1e-7)
+    assert compare_values(ref_eigenvalues["3mer-0+1+5"], nmers["3mer-0+1+5"]["chsev"][:8], atol=1e-7)
+    assert compare_values(ref_eigenvalues["4mer-0+1+2+3"], nmers["4mer-0+1+2+3"]["chsev"][:8], atol=1e-7)
+    assert compare_values(ref_eigenvalues["5mer-0+1+2+3+4"], nmers["5mer-0+1+2+3+4"]["chsev"][:8], atol=1e-7)
+
     # Test the crystal lattice energy.
     assert compare_values(0.00097592, cle, atol=1.e-8)
 


### PR DESCRIPTION
## Description
This PR speeds up the generation of nmers in CrystaLatte. This is done by:
 - Replacing list iterations with efficient numpy functions in the calculations of distance matrices, chemical space eigenvalues, and the nuclear repulsion energy
 - Changing the psithon file writer from writing one character at a time (many `os.write()` calls per input file) to a single write (one `os.write()` call per input file).
 - Improving the duplication check for potential new nmers. Previously, a potential new nmer was compared to every single existing nmer to check for duplication. Now, a potential new nmer is only compared with existing nmers with similar nuclear repulsion energies (+- 1e-5). This is accomplished by maintaining a list of existing nmers sorted by nuclear repulsion energy.

I tested this PR for correctness and efficiency using the following `.cle` input:
```
cif_input       = Benzene.cif
cif_output      = Benzene.xyz
cif_a           = 9 
cif_b           = 9 
cif_c           = 9 
nmers_up_to     = 3 
r_cut_com       = 20.0
r_cut_monomer   = 20.0
r_cut_dimer     = 18.0
r_cut_trimer    = 12.0
cle_run_type    = psithon
psi4_method     = HF/STO-3G
psi4_bsse       = nocp
psi4_memory     = 500 MB
verbose         = 2 
```
For this test, the number of dimers (88) and trimers (689) was unchanged. Also, the identities of the dimers and trimers are unchanged. I checked this by comparing the table of nmers printed by CrystaLatte. 

For this test, this PR reduces the total wall time from 903 seconds to 103 seconds (a ~9x speedup). Some other observations:
 - The BFS algorithm takes 38 seconds for this input. The remaining time is spent generating dimers and trimers
 - The dimer generation is sped up from 2.0 seconds to 0.4 seconds (a ~5x speedup)
 - The trimer generation is sped up from 862 seconds to 63 seconds (a ~14x speedup)

I expect the speedup factor (~9x here) to grow for larger supercells.

## TODO
- [x] Add additional unit tests

## Status
- [x] Ready to go